### PR TITLE
[TorchToLinalg] Fix i8 scalar dtype conversion by passing dstOriginalDtype

### DIFF
--- a/lib/Conversion/TorchToLinalg/Utils.cpp
+++ b/lib/Conversion/TorchToLinalg/Utils.cpp
@@ -633,8 +633,17 @@ Value torch_to_linalg::convertTensorToElementType(OpBuilder &b, Location loc,
                                                   Type elementType) {
   auto dtypePromoteBody = [&](OpBuilder &builder, Location loc,
                               ValueRange payloadArgs) {
-    Value elem =
-        convertScalarToDtype(builder, loc, payloadArgs[0], elementType);
+    // convertScalarToDtype requires dstOriginalDtype for 8-bit ints (byte/char semantics)                            
+    // and otherwise errors out.
+    std::optional<Type> dstOriginalDtype = std::nullopt;
+    if (auto iTy = dyn_cast<IntegerType>(elementType);
+        iTy && iTy.getWidth() == 8)
+      dstOriginalDtype = elementType;
+
+    Value elem = convertScalarToDtype(builder, loc, payloadArgs[0], elementType,
+                                      /*srcOriginalDtype=*/std::nullopt,
+                                      /*dstOriginalDtype=*/dstOriginalDtype,
+                                      /*originalScalar=*/std::nullopt);
     linalg::YieldOp::create(builder, loc, elem);
   };
   return torch_to_linalg::createElementwiseLinalgGeneric(


### PR DESCRIPTION
This fixes an `iree-compile` failure when lowering Torch programs that require converting scalars/elements to an 8-bit integer destination (Byte/Char). `convertScalarToDtype` requires` dstOriginalDtype` for i8 because `Torch` distinguishes Byte (u8) vs Char (i8) while MLIR integers are often signless; without this metadata the helper emits unimplemented.