### PR TITLE
[Torch] Support mask mod arguments in flex_attention HOP

### DIFF
--- a/include/torch-mlir/Dialect/Torch/IR/TorchOps.td
+++ b/include/torch-mlir/Dialect/Torch/IR/TorchOps.td
@@ -1468,6 +1468,11 @@ def Torch_HigherOrderFlexAttentionOp : Torch_Op<"hop_flex_attention", [
       scale: Optional float for scaling attention scores (None means 1/sqrt(head_dim))
       return_lse: Bool to return log-sum-exp values
 
+    Variadic Args:
+      mask_mod_arguments: Additional values passed to mask_mod_fn after
+        (batch, head, token_q, token_kv). These make PyTorch mask_mod closure
+        captures explicit in MLIR.
+
     Attributes:
       enable_gqa: Optional bool metadata indicating lowerings should expand
         key/value heads to query heads for grouped-query attention. When
@@ -1492,6 +1497,7 @@ def Torch_HigherOrderFlexAttentionOp : Torch_Op<"hop_flex_attention", [
     AnyTorchOptionalFloatType:$scale,
     Torch_BoolType:$return_lse,
     Torch_BoolType:$return_max_scores,
+    Variadic<AnyTorchType>:$mask_mod_arguments,
     OptionalAttr<BoolAttr>:$enable_gqa,
     OptionalAttr<FlatSymbolRefAttr>:$score_mod_fn,
     OptionalAttr<FlatSymbolRefAttr>:$mask_mod_fn
@@ -1506,10 +1512,40 @@ def Torch_HigherOrderFlexAttentionOp : Torch_Op<"hop_flex_attention", [
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
     ParseResult HigherOrderFlexAttentionOp::parse(OpAsmParser &parser, OperationState &result) {
-      return parseDefaultTorchOp(parser, result, 6, 3);
+      constexpr int64_t kMinNumOperands = 6;
+      constexpr int64_t kNumResults = 3;
+      llvm::SMLoc loc = parser.getCurrentLocation();
+      SmallVector<OpAsmParser::UnresolvedOperand> operands;
+      if (parser.parseOperandList(operands))
+        return failure();
+      if (operands.size() < kMinNumOperands)
+        return parser.emitError(loc) << "expected at least " << kMinNumOperands
+                                     << " operands";
+      if (parser.parseOptionalAttrDict(result.attributes))
+        return failure();
+      if (parser.parseColon())
+        return failure();
+      SmallVector<Type> operandTypes;
+      if (parser.parseTypeList(operandTypes))
+        return failure();
+      if (operandTypes.size() != operands.size())
+        return parser.emitError(loc) << "expected " << operands.size()
+                                     << " operand types, but got "
+                                     << operandTypes.size();
+      if (parser.resolveOperands(operands, operandTypes, loc, result.operands))
+        return failure();
+      if (parser.parseArrow())
+        return failure();
+      if (parser.parseTypeList(result.types))
+        return failure();
+      if (result.types.size() != kNumResults)
+        return parser.emitError(loc) << "expected " << kNumResults
+                                     << " result types, but got "
+                                     << result.types.size();
+      return success();
     }
     void HigherOrderFlexAttentionOp::print(OpAsmPrinter &printer) {
-      printDefaultTorchOp(printer, *this, 6, 3);
+      printDefaultTorchOp(printer, *this, getNumOperands(), 3);
     }
   }];
   let hasVerifier = 1;

--- a/python/torch_mlir/extras/fx_importer.py
+++ b/python/torch_mlir/extras/fx_importer.py
@@ -1925,19 +1925,24 @@ class GraphNodeImporter:
     ):
         """Imports the torch._higher_order_ops.flex_attention HOP.
 
-        Args format: (query, key, value, score_mod, block_mask, scale, kernel_options, ...)
+        Args format:
+        (query, key, value, score_mod, block_mask, scale, kernel_options,
+         score_mod_other_buffers, mask_mod_other_buffers, ...)
         - query, key, value: Attention input tensors
         - score_mod: Optional submodule/callable for score modification (imported as function)
         - block_mask: Optional BlockMask tuple containing mask_mod function and runtime tensors
         - scale: Optional float for attention score scaling
         - kernel_options: Optional Dict of performance tuning options:
             - return_lse: Boolean for whether to return the log-sum-exp tensor
+        - mask_mod_other_buffers: Optional values captured by the mask_mod
+            function and made explicit as op operands
 
         This creates a call to hop_flex_attention with function symbol references for
         score_mod and mask_mod.
         """
         # flex_attention HOP args from PyTorch:
-        # (query, key, value, score_mod, block_mask, scale, kernel_options, ...)
+        # (query, key, value, score_mod, block_mask, scale, kernel_options,
+        #  score_mod_other_buffers, mask_mod_other_buffers, ...)
         (
             query_arg,
             key_arg,
@@ -1947,6 +1952,7 @@ class GraphNodeImporter:
             scale_arg,
             kernel_options,
         ) = node.args[:7]
+        mask_mod_other_buffers_arg = node.args[8] if len(node.args) > 8 else ()
 
         # Import Q, K, V tensors
         query = self._import_argument(loc, query_arg, None)
@@ -2027,10 +2033,23 @@ class GraphNodeImporter:
                 self._cc.torch_bool_type,
             ).result
 
+        if isinstance(
+            mask_mod_other_buffers_arg,
+            (list, tuple, torch_fx.immutable_collections.immutable_list),
+        ):
+            mask_mod_buffer_args = list(mask_mod_other_buffers_arg)
+        elif mask_mod_other_buffers_arg is None:
+            mask_mod_buffer_args = []
+        else:
+            mask_mod_buffer_args = [mask_mod_other_buffers_arg]
+        mask_mod_arguments = [
+            self._import_argument(loc, arg, None) for arg in mask_mod_buffer_args
+        ]
+
         # Build operands for aten.flex_attention.
-        # Op expects exactly 6 operands: query, key, value, scale, return_lse, return_max_scores.
+        # Op expects 6 fixed operands followed by mask_mod_arguments:
+        # query, key, value, scale, return_lse, return_max_scores, *mask_mod_arguments.
         # Note: score_mod_fn and mask_mod_fn go as ATTRIBUTES, not operands.
-        # Note: block_mask tensors are handled by mask_mod_fn, not passed as operands.
 
         flat_operands = [
             query,
@@ -2039,7 +2058,7 @@ class GraphNodeImporter:
             scale,
             return_lse,
             return_max_scores,
-        ]
+        ] + mask_mod_arguments
 
         # Build attributes with function references
         # Only include attributes if they're not None (OptionalAttr in TableGen)

--- a/test/Dialect/Torch/ops.mlir
+++ b/test/Dialect/Torch/ops.mlir
@@ -217,6 +217,11 @@ func.func private @sdpa_mask0(%arg0: !torch.vtensor<[],si32>, %arg1: !torch.vten
   return %0 : !torch.vtensor<[],i1>
 }
 
+func.func private @sdpa_mask_with_arg(%arg0: !torch.vtensor<[],si32>, %arg1: !torch.vtensor<[],si32>, %arg2: !torch.vtensor<[],si32>, %arg3: !torch.vtensor<[],si32>, %arg4: !torch.vtensor<[2,4,8,8],i1>) -> !torch.vtensor<[],i1> {
+  %0 = torch.aten.ge.Tensor %arg2, %arg3 : !torch.vtensor<[],si32>, !torch.vtensor<[],si32> -> !torch.vtensor<[],i1>
+  return %0 : !torch.vtensor<[],i1>
+}
+
 // CHECK-LABEL: func.func @torch.hop_flex_attention
 func.func @torch.hop_flex_attention (%arg0: !torch.vtensor<[2,4,8,16],f32>, %arg1: !torch.vtensor<[2,4,8,16],f32>, %arg2: !torch.vtensor<[2,4,8,16],f32>) -> (!torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,4,8],f32>, !torch.vtensor<[2,4,8],f32>) {
   %float1.0 = torch.constant.float 1.000000e+00
@@ -228,6 +233,20 @@ func.func @torch.hop_flex_attention (%arg0: !torch.vtensor<[2,4,8,16],f32>, %arg
   // CHECK-SAME: : !torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,4,8,16],f32>, !torch.float, !torch.bool
   // CHECK-SAME: -> !torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,4,8],f32>
   %output, %logsumexp, %maxscore = torch.hop_flex_attention %arg0, %arg1, %arg2, %float1.0, %false_0, %false_0 {mask_mod_fn = @sdpa_mask0, score_mod_fn = @sdpa_score0} : !torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,4,8,16],f32>, !torch.float, !torch.bool, !torch.bool -> !torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,4,8],f32>, !torch.vtensor<[2,4,8],f32>
+  return %output, %logsumexp, %maxscore : !torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,4,8],f32>, !torch.vtensor<[2,4,8],f32>
+}
+
+// CHECK-LABEL: func.func @torch.hop_flex_attention_mask_mod_arguments
+func.func @torch.hop_flex_attention_mask_mod_arguments(%arg0: !torch.vtensor<[2,4,8,16],f32>, %arg1: !torch.vtensor<[2,4,8,16],f32>, %arg2: !torch.vtensor<[2,4,8,16],f32>, %arg3: !torch.vtensor<[2,4,8,8],i1>) -> (!torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,4,8],f32>, !torch.vtensor<[2,4,8],f32>) {
+  %float1.0 = torch.constant.float 1.000000e+00
+  %false_0 = torch.constant.bool false
+  // CHECK: %[[MASK_FLOAT:.*]] = torch.constant.float 1.000000e+00
+  // CHECK: %[[MASK_FALSE:.*]] = torch.constant.bool false
+  // CHECK: torch.hop_flex_attention %arg0, %arg1, %arg2, %[[MASK_FLOAT]], %[[MASK_FALSE]], %[[MASK_FALSE]], %arg3
+  // CHECK-SAME: {mask_mod_fn = @sdpa_mask_with_arg, score_mod_fn = @sdpa_score0}
+  // CHECK-SAME: : !torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,4,8,16],f32>, !torch.float, !torch.bool, !torch.bool, !torch.vtensor<[2,4,8,8],i1>
+  // CHECK-SAME: -> !torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,4,8],f32>, !torch.vtensor<[2,4,8],f32>
+  %output, %logsumexp, %maxscore = torch.hop_flex_attention %arg0, %arg1, %arg2, %float1.0, %false_0, %false_0, %arg3 {mask_mod_fn = @sdpa_mask_with_arg, score_mod_fn = @sdpa_score0} : !torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,4,8,16],f32>, !torch.float, !torch.bool, !torch.bool, !torch.vtensor<[2,4,8,8],i1> -> !torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,4,8],f32>, !torch.vtensor<[2,4,8],f32>
   return %output, %logsumexp, %maxscore : !torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,4,8],f32>, !torch.vtensor<[2,4,8],f32>
 }
 

--- a/test/python/fx_importer/basic_test.py
+++ b/test/python/fx_importer/basic_test.py
@@ -437,6 +437,94 @@ def test_flex_attention_noblock_return_lse():
 
 
 @run
+# CHECK-LABEL: test_flex_attention_mask_mod_argument
+# Check that helper functions are emitted first.
+# CHECK: func.func private @[[SCORE_FN:sdpa_score[0-9]+]](%arg0: !torch.vtensor<[],f32>, %arg1: !torch.vtensor<[],si32>, %arg2: !torch.vtensor<[],si32>, %arg3: !torch.vtensor<[],si32>, %arg4: !torch.vtensor<[],si32>) -> !torch.vtensor<[],f32>
+# CHECK: func.func private @[[MASK_FN:sdpa_mask[0-9]+]](%arg0: !torch.vtensor<[],si32>, %arg1: !torch.vtensor<[],si32>, %arg2: !torch.vtensor<[],si32>, %arg3: !torch.vtensor<[],si32>, %arg4: !torch.vtensor<[4,8,1024,1024],i1>) -> !torch.vtensor<[],i1>
+# Then check the main function.
+# CHECK: func.func @test_flex_attention_mask_mod_argument(%arg0: !torch.vtensor<[4,8,1024,64],f32>, %arg1: !torch.vtensor<[4,8,1024,64],f32>, %arg2: !torch.vtensor<[4,8,1024,64],f32>, %arg3: !torch.vtensor<[4,8,1024,1024],i1>)
+# CHECK-SAME: -> !torch.vtensor<[4,8,1024,64],f32>
+# Validate flex_attention op with a trailing mask_mod argument operand:
+# CHECK: %[[SCALE:.*]] = torch.constant.float 1.000000e+00
+# CHECK: %[[RETURN_LSE:.*]] = torch.constant.bool false
+# CHECK: %[[RETURN_MAX:.*]] = torch.constant.bool false
+# CHECK: %[[OUTPUT:.*]], %[[LOGSUMEXP:.*]], %[[MAX_SCORES:.*]] = torch.hop_flex_attention %arg0, %arg1, %arg2, %[[SCALE]], %[[RETURN_LSE]], %[[RETURN_MAX]], %arg3 {mask_mod_fn = @[[MASK_FN]], score_mod_fn = @[[SCORE_FN]]}
+# CHECK-SAME: : !torch.vtensor<[4,8,1024,64],f32>, !torch.vtensor<[4,8,1024,64],f32>, !torch.vtensor<[4,8,1024,64],f32>, !torch.float, !torch.bool, !torch.bool, !torch.vtensor<[4,8,1024,1024],i1>
+# CHECK-SAME: -> !torch.vtensor<[4,8,1024,64],f32>, !torch.vtensor<[4,8,1024],f32>, !torch.vtensor<[4,8,1024],f32>
+# CHECK: return %[[OUTPUT]]
+def test_flex_attention_mask_mod_argument():
+    from torch._higher_order_ops.flex_attention import (
+        flex_attention as flex_attention_hop,
+    )
+    from torch._subclasses.fake_tensor import FakeTensor
+    from torch.nn.attention.flex_attention import BlockMask, _LARGE_SPARSE_BLOCK_SIZE
+    from torch import Tensor
+
+    def _create_empty_block_mask(query: Tensor, key: Tensor, mask_mod):
+        device = query.device
+        return BlockMask.from_kv_blocks(
+            kv_num_blocks=torch.ones([1, 1, 1], dtype=torch.int32, device=device),
+            kv_indices=torch.zeros([1, 1, 1, 1], dtype=torch.int32, device=device),
+            BLOCK_SIZE=_LARGE_SPARSE_BLOCK_SIZE,
+            mask_mod=mask_mod,
+            seq_lengths=(query.shape[-2], key.shape[-2]),
+        )
+
+    def relative_position_bias(
+        score: Tensor,
+        batch: Tensor,
+        head: Tensor,
+        token_q: Tensor,
+        token_kv: Tensor,
+    ) -> Tensor:
+        return torch.tanh(score)
+
+    def explicit_mask(
+        batch: Tensor,
+        head: Tensor,
+        token_q: Tensor,
+        token_kv: Tensor,
+        attn_mask: Tensor,
+    ) -> Tensor:
+        return attn_mask[batch, head, token_q, token_kv]
+
+    class FlexAttention(torch.nn.Module):
+        def __init__(self, block_mask):
+            super().__init__()
+            self.block_mask = block_mask
+
+        def forward(self, q, k, v, attn_mask):
+            output, _, _ = flex_attention_hop(
+                q,
+                k,
+                v,
+                relative_position_bias,
+                self.block_mask.as_tuple(),
+                1.0,
+                {},
+                (),
+                (attn_mask,),
+            )
+            assert isinstance(output, FakeTensor)
+            return output
+
+    B, Hq, Hkv, L, S, E, Ev = 4, 8, 8, 1024, 1024, 64, 64
+    q = torch.ones(B, Hq, L, E)
+    k = torch.ones(B, Hkv, S, E)
+    v = torch.ones(B, Hkv, S, Ev)
+    attn_mask = torch.ones(B, Hq, L, S, dtype=torch.bool)
+    m = fx.export_and_import(
+        FlexAttention(_create_empty_block_mask(q, k, explicit_mask)),
+        q,
+        k,
+        v,
+        attn_mask,
+        func_name="test_flex_attention_mask_mod_argument",
+    )
+    print(m)
+
+
+@run
 # CHECK-LABEL: test_stack_trace
 # CHECK: #loc[[LOC1:.+]] = loc(
 # CHECK: %{{.+}} = torch.aten.add.Tensor {{.+}} loc(#loc[[LOC1]])


### PR DESCRIPTION
PyTorch flex_attention passes mask_mod closure captures as mask_mod_other_buffers, but torch.hop_flex_attention only modeled the mask function symbol. This adds trailing variadic mask_mod_arguments operands so explicit attention masks and other captures can be represented in Torch IR.

The FX importer forwards mask_mod_other_buffers into those operands while keeping score_mod_fn and mask_mod_fn as symbol attributes. Tests cover textual round-tripping and importer emission for an explicit attention mask capture.

Tests: cmake --build /home/keshavvinayakjha/Desktop/code/iree-worktrees/torch-mlir-flex-mask-mod-args/build --target torch-mlir-opt; llvm-lit -sv /home/keshavvinayakjha/Desktop/code/iree-worktrees/torch-mlir-flex-mask-mod-args/build/test/Dialect/Torch/ops.mlir; PyTorch export smoke test for HOP mask_mod_other_buffers.
